### PR TITLE
Link to GoDaddy help page for Glue Record setup (called Host Names)

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -239,7 +239,7 @@
 
 	    			<h3>Glue Records</h3>
 
-	    			<p>First, you&rsquo;ll create two &ldquo;glue records.&rdquo; The purpose of glue records is to say that your box is becoming a part of the domain name system. These records go by different names at different registrars, so also look out for &ldquo;hostnames&rdquo; or &ldquo;child nameservers.&rdquo;. This will <em>not</em> be found in a DNS control panel. [<a href="http://wiki.gandi.net/en/domains/management/change-glue">Gandi instructions</a>]</p>
+	    			<p>First, you&rsquo;ll create two &ldquo;glue records.&rdquo; The purpose of glue records is to say that your box is becoming a part of the domain name system. These records go by different names at different registrars, so also look out for &ldquo;hostnames&rdquo; or &ldquo;child nameservers.&rdquo;. This will <em>not</em> be found in a DNS control panel. [<a href="http://wiki.gandi.net/en/domains/management/change-glue">Gandi instructions</a> | <a href="https://support.godaddy.com/help/article/664/setting-nameservers-for-your-domain-names">GoDaddy instructions</a>]</p>
 
 	    			<p>A glue record consists of a hostname and an IP address. For historical reasons we need two glue records. The two records you need to create are for <code>ns1</code> + <code>.</code> + your box&rsquo;s hostname and <code>ns2</code> + <code>.</code> + your box&rsquo;s hostname. (They stand for &ldquo;nameserver one&rdquo; and &ldquo;nameserver two&rdquo;.) For the IP address, enter the IP address of your box.</p>
 


### PR DESCRIPTION
I struggled for half a day to find any mention of how to set up Glue
Records on GoDaddy -- mainly because there's no mention of the term on
their website.

Turns out that they refer to these as "Host Names" (a rather generic
term that doesn't help when you search for it either).

Adding a link to a page that is at somewhat helpful in locating this.

![glue-records](https://cloud.githubusercontent.com/assets/63734/4260772/42879b86-3b4d-11e4-8a6d-7b6ddcada1a7.png)
