### PR TITLE
fixes "Fork me on GitHub" link

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -125,7 +125,7 @@
     </style>
 </head>
 <body data-spy="scroll" data-target="#nav">
-	<a href="https://github.com/mail-in-a-box/mailinabox.email/blob/master/guide.html" class="visible-md visible-lg"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+	<a href="https://github.com/mail-in-a-box/mailinabox" class="visible-md visible-lg"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
 
 	<div id="back">
 		<div class="container">


### PR DESCRIPTION
Fork me on Github on https://mailinabox.email/guide.html is pointing to https://github.com/mail-in-a-box/mailinabox.email/blob/master/guide.html instead of https://github.com/mail-in-a-box/mailinabox