### PR TITLE
Add .network to good TLDs

### DIFF
--- a/tld-quirks.html
+++ b/tld-quirks.html
@@ -82,6 +82,7 @@
 	    			<ul class="tld-list">
 	    				<li>.eu</li>
 	    				<li>.computer</li>
+	    				<li>.network</li>
 	    			</ul>
 
 	    			<p>Known to have DNSSEC problems:</p>


### PR DESCRIPTION
I'm using this on a .network TLD and it's working fine, but I haven't tried setting up DNSSEC.