### PR TITLE
Remove redundant smtp_use_tls setting from example relay configuration

### DIFF
--- a/advanced-configuration.html
+++ b/advanced-configuration.html
@@ -62,7 +62,6 @@
 						<li>
 							<p>Append the following seven lines to <code>/etc/postfix/main.cf</code>:</p>
 							<pre><code>mydestination = 
-smtp_use_tls = yes
 smtp_tls_security_level = verify
 smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
 smtp_sasl_auth_enable = yes


### PR DESCRIPTION
smtp_tls_security_level supercedes this, as per http://www.postfix.org/postconf.5.html#smtp_use_tls.