### PR TITLE
Add POP3 to the Hardware Firewall Instructions

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -229,7 +229,7 @@
 
 	    			<h3>Firewall settings</h3>
 
-	    			<p>If your machine is behind a hardware firewall (or virtual equivalent, such as an AWS security group), ensure that the following ports are open: 22 (SSH), 25 (SMTP), 53 (DNS; must be open for both tcp &amp; udp), 80 (HTTP), 443 (HTTPS), 587 (SMTP submission), and 993 (IMAP). It doesn&rsquo;t hurt to block other ports, but your box will take care of that itself by configuring a software firewall on the machine itself.</p>
+	    			<p>If your machine is behind a hardware firewall (or virtual equivalent, such as an AWS security group), ensure that the following ports are open: 22 (SSH), 25 (SMTP), 53 (DNS; must be open for both tcp &amp; udp), 80 (HTTP), 443 (HTTPS), 587 (SMTP submission), 993 (IMAP) and 995 (POP). It doesn&rsquo;t hurt to block other ports, but your box will take care of that itself by configuring a software firewall on the machine itself.</p>
 
 
 	    			<h2 id="glue-records">Domain Name Configuration &mdash; Glue Records</h2>


### PR DESCRIPTION
According to adding POP3 to the Mail Instructions Page, i think we shoud inform users that they need to open port 995 for that (if they use an hardware firewall).