### PR TITLE
Add ".is"-TLD to "Avoid these:" List

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -170,6 +170,7 @@
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
 	   	    			<li title="requires two nameservers">.ca</li>
 	    				<li title="requires two nameservers">.de</li>
+	    				<li title="requires two nameservers">.is</li>
 	    				<li title="requires two nameservers">.nl</li> <!-- https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3 -->
 	    			</ul>
 


### PR DESCRIPTION
As discussed here: https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077