### PR TITLE
Adding detail to guide on TLD to avoid

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -156,7 +156,7 @@
 	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse Discussion and the requirements directly from the registry's themsleves. Summaries of each of these resources can be found here:</p>
 
 	    			<ul class="tld-list">
-	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>
+	    				<li class="heading">Mail-in-a-Box Discourse discussions:</li>
 	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
 	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077">.is</a></li>
 	    			</ul>

--- a/guide.html
+++ b/guide.html
@@ -149,9 +149,19 @@
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
 	   	    			<li title="requires two nameservers">.ca</li>
 	    				<li title="requires two nameservers">.de</li>
-	    				<li title="requires two nameservers"><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
-	    				<li title="own A record in DNS; NS needs own PTR resource record"><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a> <a href="">ISNIC requirements</a></li>
+	    				<li title="requires two nameservers">.nl</a></li>
+	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is</li>
 	    			</ul>
+	    			
+	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse Discussion and the requirements directly from the registry's themsleves.</p>
+
+	    			<ul class="tld-list" style="margin-bottom: 14px">
+	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>
+	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
+	    				<li></li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a></li>
+					<li class="heading">Registry official requirements:</li>
+					<li><a href="https://www.isnic.is/en/host/req">.is</a></li>
+				</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>
 

--- a/guide.html
+++ b/guide.html
@@ -153,7 +153,7 @@
 	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>&diams;</a></li>
 	    			</ul>
 	    			
-	    			<ul class="tld-list" style="margin-bottom: 14px"></ul>
+	    			<ul class="tld-list" style="margin-bottom: 14px">
 	    				<li>&diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a></li>
 	    				<li>&Delta; TLD Registry</li>
 	    			</ul>

--- a/guide.html
+++ b/guide.html
@@ -153,7 +153,7 @@
 	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is</li>
 	    			</ul>
 	    			
-	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse Discussion and the requirements directly from the registry's themsleves.</p>
+	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse Discussion and the requirements directly from the registry's themsleves. Summaries of each of these resources can be found here:</p>
 
 	    			<ul class="tld-list">
 	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>

--- a/guide.html
+++ b/guide.html
@@ -154,6 +154,7 @@
 	    			</ul>
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">
+	    				<li class="heading"></li>
 	    				<li>&diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a></li>
 	    				<li>&Delta; TLD Registry</li>
 	    			</ul>

--- a/guide.html
+++ b/guide.html
@@ -158,7 +158,7 @@
 	    			<ul class="tld-list" style="margin-bottom: 14px">
 	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>
 	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
-	    				<li></li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a></li>
+	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a></li>
 	    			</ul>
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">

--- a/guide.html
+++ b/guide.html
@@ -149,7 +149,8 @@
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
 	   	    			<li title="requires two nameservers">.ca</li>
 	    				<li title="requires two nameservers">.de</li>
-	    				<li title="requires two nameservers">.nl</li> <!-- https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3 -->
+	    				<li title="requires two nameservers"><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
+	    				<li title="own A record in DNS; NS needs own PTR resource record"><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a> <a href="">ISNIC requirements</a></li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -151,7 +151,9 @@
 	    				<li title="requires two nameservers">.de</li>
 	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is <a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077"</a>MIAB</a> <a href="https://www.isnic.is/en/host/req">Registry</a></li>
 	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>MIAB</a> <a href="">Registry</a></li>
-	    				<li>Legend: <em>MIAB:</em> links to Mail-in-a-Box Discourse site | <em>Registry:</em> official registry requirements per TLD</li>
+	    				<li class="heading">Legend:</li></li>
+	    				<li><em>MIAB:</em> links to Mail-in-a-Box Discourse site</li>
+	    				<li><em>Registry:</em> official registry requirements per TLD</li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -158,7 +158,7 @@
 	    			<ul class="tld-list">
 	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>
 	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
-	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a></li>
+	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077">.is</a></li>
 	    			</ul>
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">

--- a/guide.html
+++ b/guide.html
@@ -147,25 +147,12 @@
 	    			<ul class="tld-list" style="margin-bottom: 14px">
 	    				<li class="heading">Avoid these:</li>
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
-	   	    			<li title="requires two nameservers">.ca</li>
+	   	    			<li title="requires two nameservers">.ca <a href="https://discourse.mailinabox.email/t/why-is-a-ca-domain-listed-as-avoid/1008/2"></a></li>
 	    				<li title="requires two nameservers">.de</li>
-	    				<li title="requires two nameservers">.nl</li>
-	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is</li>
+	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is <a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077"</a>MIAB</a> <a href="https://www.isnic.is/en/host/req">Registry</a></li>
+	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>MIAB</a> <a href="">Registry</a></li>
+	    				<li>Legend: <em>MIAB:</em> links to Mail-in-a-Box Discourse site | <em>Registry:</em> official registry requirements per TLD</li>
 	    			</ul>
-	    			
-	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse discussions and the requirements directly from the registry's themsleves. Summaries of each of these resources can be found here:</p>
-
-	    			<ul class="tld-list">
-	    				<li class="heading">Mail-in-a-Box Discourse discussions:</li>
-	    				<li><a href="https://discourse.mailinabox.email/t/why-is-a-ca-domain-listed-as-avoid/1008/2">.ca</a></li>
-	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077">.is</a></li>
-	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
-	    			</ul>
-	    			
-	    			<ul class="tld-list" style="margin-bottom: 14px">
-					<li class="heading">Registry official requirements:</li>
-					<li><a href="https://www.isnic.is/en/host/req">.is</a></li>
-				</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>
 

--- a/guide.html
+++ b/guide.html
@@ -157,8 +157,9 @@
 
 	    			<ul class="tld-list">
 	    				<li class="heading">Mail-in-a-Box Discourse discussions:</li>
-	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
+	    				<li><a href="https://discourse.mailinabox.email/t/why-is-a-ca-domain-listed-as-avoid/1008/2">.ca</a></li>
 	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077">.is</a></li>
+	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
 	    			</ul>
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">

--- a/guide.html
+++ b/guide.html
@@ -153,7 +153,7 @@
 	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is</li>
 	    			</ul>
 	    			
-	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse Discussion and the requirements directly from the registry's themsleves. Summaries of each of these resources can be found here:</p>
+	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse discussions and the requirements directly from the registry's themsleves. Summaries of each of these resources can be found here:</p>
 
 	    			<ul class="tld-list">
 	    				<li class="heading">Mail-in-a-Box Discourse discussions:</li>

--- a/guide.html
+++ b/guide.html
@@ -159,6 +159,9 @@
 	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>
 	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
 	    				<li></li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a></li>
+	    			</ul>
+	    			
+	    			<ul class="tld-list" style="margin-bottom: 14px">
 					<li class="heading">Registry official requirements:</li>
 					<li><a href="https://www.isnic.is/en/host/req">.is</a></li>
 				</ul>

--- a/guide.html
+++ b/guide.html
@@ -153,10 +153,9 @@
 	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>&diams;</a></li>
 	    			</ul>
 	    			
-	    			<ul class="tld-list" style="margin-bottom: 14px">
-	    				<li class="heading">Links legend:</li></li>
-	    				<li>&diams; MIAB Discourse</li>
-	    				<li>&Delta; Registry</li>
+	    			<ul class="tld-list" style="margin-bottom: 14px"></ul>
+	    				<li>&diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a></li>
+	    				<li>&Delta; TLD Registry</li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -147,13 +147,16 @@
 	    			<ul class="tld-list" style="margin-bottom: 14px">
 	    				<li class="heading">Avoid these:</li>
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
-	   	    			<li title="requires two nameservers">.ca <a href="https://discourse.mailinabox.email/t/why-is-a-ca-domain-listed-as-avoid/1008/2"></a></li>
+	   	    			<li title="requires two nameservers">.ca <a href="https://discourse.mailinabox.email/t/why-is-a-ca-domain-listed-as-avoid/1008/2">&diams;</a></li>
 	    				<li title="requires two nameservers">.de</li>
-	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is <a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077"</a>MIAB</a> <a href="https://www.isnic.is/en/host/req">Registry</a></li>
-	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>MIAB</a> <a href="">Registry</a></li>
-	    				<li class="heading">Legend:</li></li>
-	    				<li><em>MIAB:</em> links to Mail-in-a-Box Discourse site</li>
-	    				<li><em>Registry:</em> official registry requirements per TLD</li>
+	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is <a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077"</a>&diams;</a> <a href="https://www.isnic.is/en/host/req">&Delta;</a></li>
+	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>&diams;</a></li>
+	    			</ul>
+	    			
+	    			<ul class="tld-list" style="margin-top: -10px">
+	    				<li class="heading">Links legend:</li></li>
+	    				<li>&diams; links to Mail-in-a-Box Discourse site</li>
+	    				<li>&Delta; official registry requirements per TLD</li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -155,7 +155,7 @@
 	    			
 	    			<p>If you are considering one of the "avoid" TLDs above, you might wish to review both the official Mail-in-a-Box Discourse Discussion and the requirements directly from the registry's themsleves.</p>
 
-	    			<ul class="tld-list" style="margin-bottom: 14px">
+	    			<ul class="tld-list">
 	    				<li class="heading">Mail-in-a-box Discourse discussions:</li>
 	    				<li><a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3">.nl</a></li>
 	    				<li><a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077/3">.is</a></li>

--- a/guide.html
+++ b/guide.html
@@ -155,7 +155,7 @@
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">
 	    				<li class="heading">Legend:</li>
-	    				<li>TLD &diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a> &Delta; TLD Registry</li>
+	    				<li>TLD &diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a> &Delta; Registry</li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -154,7 +154,7 @@
 	    			</ul>
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">
-	    				<li class="heading">Legend: </li>
+	    				<li class="heading">Legend:</li>
 	    				<li>TLD &diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a> &Delta; TLD Registry</li>
 	    			</ul>
 

--- a/guide.html
+++ b/guide.html
@@ -154,9 +154,8 @@
 	    			</ul>
 	    			
 	    			<ul class="tld-list" style="margin-bottom: 14px">
-	    				<li class="heading"></li>
-	    				<li>&diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a></li>
-	    				<li>&Delta; TLD Registry</li>
+	    				<li class="heading">Legend: </li>
+	    				<li>TLD &diams; <a href="https://discourse.mailinabox.email">MIAB Discourse</a> &Delta; TLD Registry</li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -144,7 +144,7 @@
 	    				<li>.nz</li>
 	    			</ul>
 
-	    			<ul class="tld-list" style="margin-bottom: 14px">
+	    			<ul class="tld-list">
 	    				<li class="heading">Avoid these:</li>
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
 	   	    			<li title="requires two nameservers">.ca <a href="https://discourse.mailinabox.email/t/why-is-a-ca-domain-listed-as-avoid/1008/2">&diams;</a></li>
@@ -153,10 +153,10 @@
 	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a>&diams;</a></li>
 	    			</ul>
 	    			
-	    			<ul class="tld-list" style="margin-top: -10px">
+	    			<ul class="tld-list" style="margin-bottom: 14px">
 	    				<li class="heading">Links legend:</li></li>
-	    				<li>&diams; links to Mail-in-a-Box Discourse site</li>
-	    				<li>&Delta; official registry requirements per TLD</li>
+	    				<li>&diams; MIAB Discourse</li>
+	    				<li>&Delta; Registry</li>
 	    			</ul>
 
 	    			<p>Next you will register your new domain name. It&rsquo;s about $17/year, depending on the TLD. Buy basically anything you want, taking into account the TLD recommendations above. This will be the start of your new identity.</p>

--- a/guide.html
+++ b/guide.html
@@ -149,7 +149,7 @@
 	   	    			<li title="may require two nameservers, may not support DNSSEC">.at</li>
 	   	    			<li title="requires two nameservers">.ca</li>
 	    				<li title="requires two nameservers">.de</li>
-	    				<li title="requires two nameservers">.nl</a></li>
+	    				<li title="requires two nameservers">.nl</li>
 	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is</li>
 	    			</ul>
 	    			


### PR DESCRIPTION
I've added reference links to the Discourse site and the registry to help people understand better why some domains don't work well with MIAB.