### PR TITLE
HTTPS where possible & SpamAssassin Typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
 					<ul>
 					<li>Make deploying a good mail server easy.</li>
 					<li>Promote <a href="http://redecentralize.org/">decentralization</a>, innovation, and privacy on the web.</li>
-					<li>Have automated, auditable, and <a href="http://sharknet.us/2014/02/01/automated-configuration-management-challenges-with-idempotency/">idempotent</a> system configuration.</li>
+					<li>Have automated, auditable, and <a href="https://sharknet.us/2014/02/01/automated-configuration-management-challenges-with-idempotency/">idempotent</a> system configuration.</li>
 					<li><strong>Not</strong> make a totally unhackable, NSA-proof server (but see our <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/security.md">security practices</a>).</li>
 					<li><strong>Not</strong> make something customizable by power users.</li>
 					</ul>
@@ -322,7 +322,7 @@
 
 					<p>Mail-in-a-Box is similar to <a href="http://www.iredmail.org/">iRedMail</a> and <a href="https://github.com/tonioo/modoboa">Modoboa</a>.</p>
 
-					<p>Mail-in-a-Box is based on <a href="http://www.postfix.org/">Postfix</a>, <a href="http://dovecot.org/">Dovecot</a>, <a href="http://z-push.org/">Z-Push</a>, <a href="http://roundcube.net/">Roundcube</a>, <a href="http://owncloud.org/">ownCloud</a>, <a href="https://spamassassin.apache.org/">Spamassassin</a>, <a href="http://postgrey.schweikert.ch/">Postgrey</a>, <a href="http://nginx.org/">Nginx</a>, <a href="https://gist.github.com/konklone/6532544">@konklone&rsquo;s nginx config</a>, and more.</p>
+					<p>Mail-in-a-Box is based on <a href="http://www.postfix.org/">Postfix</a>, <a href="http://dovecot.org/">Dovecot</a>, <a href="http://z-push.org/">Z-Push</a>, <a href="https://roundcube.net/">Roundcube</a>, <a href="http://owncloud.org/">ownCloud</a>, <a href="https://spamassassin.apache.org/">Apache SpamAssassin</a>, <a href="http://postgrey.schweikert.ch/">Postgrey</a>, <a href="http://nginx.org/">Nginx</a>, <a href="https://gist.github.com/konklone/6532544">@konklone&rsquo;s nginx config</a>, and more.</p>
 
 					<div style="height: 100px"> </div>
 				</div>


### PR DESCRIPTION
Checked where HTTPS is possible with the given HTTP links (only taken if they are redirecting to the same site, without any self-signed certificate).
Spamassassin is called "Apache SpamAssassin" ;)