### PR TITLE
Update maintenance.html

### DIFF
--- a/maintenance.html
+++ b/maintenance.html
@@ -176,7 +176,7 @@ export AWS_SECRET_ACCESS_KEY=paste your AWS secret access key here
 export PASSPHRASE=$(cat your_backup_secret_key_file.txt)
 sudo -E duplicity restore s3://s3.amazonaws.com/your-bucket-name/your-backup-path /home/user-data/</pre>
 
-					<p>You may have to adjust the S3 URL depending on what AWS region you use.</p>
+					<p>You may have to adjust the S3 URL depending on what AWS region you use. You can find the AWS Regions and Endpoints <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">here</a></p>
 
 					<h3>Re-configure the box</h3>
 


### PR DESCRIPTION
Added a link to the Amazon Simple Storage Service (Amazon S3) website, that lists all the endpoints.
I had problems while trying to migrate mailinabox to a new server, as I used the wrong endpoint.
Amazon does not really follow a naming convention here. 
For example: s3.eu-central-1.amazonaws.com and s3-eu-central-1.amazonaws.com are valid, but s3.eu-west-1.amazonaws.com is not (only s3-eu-west-1.amazonaws.com)!