### PR TITLE
Add upgrade-current-box step to the migrate-to-new-box instructions 

### DIFF
--- a/maintenance.html
+++ b/maintenance.html
@@ -131,6 +131,10 @@
 	    				<p>Even if your box is working fine, it&rsquo;s a good idea to test out this procedure from time to time so that you can verify that your backups are working and that you haven&rsquo;t lost the backup secret key.</p>
 					</div>
 
+				<h3>Upgrade your current box to the latest version</h3>
+				
+				<p>To make the transition as smooth as possible, simply follow the instructions above to upgrade your current box to the latest version before proceeding to the new box.</p>
+				
 	    			<h3>Create a new box</h3>
 
 	    			<p>Start by creating a new Mail-in-a-Box machine: Spin up a new machine following the setup guide&rsquo;s sections <a href="guide.html#machine">The Machine</a> and <a href="guide.html#setup">Setting Up The Box</a>. At this point you will have a mostly working, but empty, Mail-in-a-Box on your new machine.</p>


### PR DESCRIPTION
The transition will fail if the current box is not at the latest version of MIAB. All users should upgrade the current box before proceeding onto the new one.