### PR TITLE
Add SpamAssassin suspicious nTLDs to list of TLDs to avoid

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -136,7 +136,6 @@
 	    				<li>.uk</li>
 	    				<li>.me.uk</li>
 	    				<li>.us</li>
-	    				<li>.xyz</li>
 	    			</ul>
 
 	    			<ul class="tld-list">
@@ -146,7 +145,6 @@
 	    				<li>.eu</li>
 	    				<li>.im</li>
 	    				<li>.name</li>
-	    				<li>.net</li>
 	    				<li>.network</li>
 	    				<li>.nz</li>
 	    			</ul>
@@ -159,6 +157,7 @@
 					<li title="may require two nameservers, will not support nameservers on sub-domain">.gg .je .as</li>
 	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is <a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077"</a><i class="glyphicon glyphicon-comment" title="Link to discussion thread."></i></a> <a href="https://www.isnic.is/en/host/req"><i class="glyphicon glyphicon-globe" title="Link to registry requirements."></i></a></li>
 	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a><i class="glyphicon glyphicon-comment" title="Link to discussion thread."></i></a></li>
+					<li title="SpamAssassin suspicious nTLDs">.bid .buzz .click .date .faith .fit .fun .gdn .icu .life .online .ooo .pro .review .site .space .stream .top .work .world .xyz</li>
 
 		    			<div><i class="glyphicon glyphicon-comment"></i> indicates link to discussion. <i class="glyphicon glyphicon-globe" title="Link to registry requirements."></i> indicates link to TLD registry requirements.</li>
 	    			</ul>


### PR DESCRIPTION
I was trying to use Mail-in-a-Box with a .xyz domain, but SpamAssassin penalizes certain nTLDs so much that even the Mail-in-a-Box status emails (being sent to an account on the same server!) were going to the junk mail folder.

See https://github.com/apache/spamassassin/blob/8d2998f5175e458b6927131c5365edd413448365/rulesrc/sandbox/pds/20_ntld.cf

(Also, .net was in two lists, so I removed the duplicate.)