### PR TITLE
Flesh out information on backups (and a little extra for 0.30 → current)

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -368,6 +368,20 @@ C0:9B:FF:04:2B:2D:8F:47:5A:8B:D5:88:B7:05:D3:4B:6C:22:80:5F</pre>
 
 					<p>You can also add or remove additional email accounts and mail aliases (forwarders).</p>
 
+					<h3>Backup status</h3>
+
+					<p>Here you can configure backups, and get an overview of what has been backed up to date. Backups are encrypted, and are therefore safe to store anywhere you like.</p>
+
+					<p>By default, backups are stored on the box.  You can also configure rsync to copy those local backups to another server, or store backups entirely on Amazon S3, or another compatible service (e.g. <a href="https://www.digitalocean.com/products/spaces/">DigitalOcean Spaces</a>). With S3, no backups are stored locally, preserving some disk space on the box.</p>
+
+					<p>
+					However you store your backups, you must copy the encryption password file described on the Backup Status screen somewhere safe!  Backups cannot be decrypted without the backup key!
+					</p>
+
+					<div class="alert alert-warning">
+						If you're using an S3-compatible service instead of Amazon S3, be aware that mailinabox is not currently compatible with version 4 authentication signatures.  This will rule out some services like <a href="https://www.backblaze.com/b2/docs/s3_compatible_api.html" target="_blank" rel="noopener">Backblaze B2</a>, which currently requires that version.
+					</div>
+
 					<h3>Advanced tools</h3>
 
 					<p>The administrative control panel also helps you with...</p>
@@ -375,7 +389,6 @@ C0:9B:FF:04:2B:2D:8F:47:5A:8B:D5:88:B7:05:D3:4B:6C:22:80:5F</pre>
 					<ul>
 					<li>Setting up contact and calendar synchronization</li>
 					<li>Publishing a static website</li>
-					<li>Checking the status of backups</li>
 					<li>Setting custom DNS records, e.g. if you run a website on the same domain name but on another machine</li>
 					</ul>
 

--- a/guide.html
+++ b/guide.html
@@ -378,10 +378,6 @@ C0:9B:FF:04:2B:2D:8F:47:5A:8B:D5:88:B7:05:D3:4B:6C:22:80:5F</pre>
 					However you store your backups, you must copy the encryption password file described on the Backup Status screen somewhere safe!  Backups cannot be decrypted without the backup key!
 					</p>
 
-					<div class="alert alert-warning">
-						If you're using an S3-compatible service instead of Amazon S3, be aware that mailinabox is not currently compatible with version 4 authentication signatures.  This will rule out some services like <a href="https://www.backblaze.com/b2/docs/s3_compatible_api.html" target="_blank" rel="noopener">Backblaze B2</a>, which currently requires that version.
-					</div>
-
 					<h3>Advanced tools</h3>
 
 					<p>The administrative control panel also helps you with...</p>

--- a/maintenance.html
+++ b/maintenance.html
@@ -115,7 +115,7 @@
 
 					<div class="alert alert-warning" role="alert">
 	    				<p>If you are upgrading from Mail-in-a-Box version v0.30 or earlier on <strong>Ubuntu 14.04</strong> to version 0.40 or later on <strong>Ubuntu 18.04</strong>:</p>
-	    				<p>1. Follow the instructions in this section to upgrade your existing Mail-in-a-Box to v0.30, the last version supporting Ubuntu 14.04.</p>
+	    				<p>1. Follow the instructions in this section to upgrade your existing Mail-in-a-Box to v0.30, the last version supporting Ubuntu 14.04. (<a href="https://discourse.mailinabox.email/t/mail-in-a-box-version-v0-40-and-moving-to-ubuntu-18-04/4289">As noted in the forum</a>, upgrading the Nextcloud components can be challenging now due to package deprecation.)</p>
 	    				<p>2. After your existing box is up to date with v0.30, then proceed to the section below <strong>Moving to a New Box</strong> to migrate your system to a new machine running Ubuntu 18.04 and version 0.40 of Mail-in-a-Box.</p>
 	    			</div>
 	    				


### PR DESCRIPTION
I wanted to see a little more detail in the maintenance guide about setting up backups, so I've written a little bit about it.  I specifically wanted to address how S3-compatible services are usable as long as they're compatible with the older version of the S3 authentication API (i.e. v2 signatures work, v4 signatures don't). This rules out the alternative service I wanted to use, Backblaze B2), at least for now.  I'd like to write a PR that could fix the empty error messages trying to use B2 gives you, but at least for now I can submit some documentation.

I also just finished upgrading my box from 0.30 to 0.45, and hit a snag because I didn't totally follow whether the main documentation would carry me through or not.  Specifically, I missed the bit about moving the user-data directory before restoring my backups from S3.  So I've added another link to the forum instructions for this upgrade path earlier in the setup guide. Hopefully there aren't too many of us who had the old 14.04 boxes still lying around, but just in case!