### PR TITLE
Remove DigitalOcean recommendation

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -191,7 +191,7 @@
 
 	    			<h3>Finding a cloud service provider</h3>
 
-	    			<p>Now you will rent a machine, or a virtual part of a machine, somewhere in &ldquo;the cloud.&rdquo; We&rsquo;ll call this machine your box. We recommend going over to <a href="https://www.digitalocean.com/">Digital Ocean</a>, <a href="https://www.linode.com/">Linode</a>, <a href="http://www.1and1.com/">1&amp;1</a>, or <a href="http://rimuhosting.com/order/v2orderstart.jsp">Rimuhosting.com</a>. (Most any cloud provider will do, but not Amazon Web Services because its network is often blocked to prevent users from sending spam.)</p>
+	    			<p>Now you will rent a machine, or a virtual part of a machine, somewhere in &ldquo;the cloud.&rdquo; We&rsquo;ll call this machine your box. We recommend going over to <a href="https://www.linode.com/">Linode</a>, <a href="http://www.1and1.com/">1&amp;1</a>, or <a href="http://rimuhosting.com/order/v2orderstart.jsp">Rimuhosting.com</a>. (Most any cloud provider will do, but not Amazon Web Services because its network is often blocked to prevent users from sending spam.)</p>
 
 					<p><strong>You must choose the <code>Ubuntu 18.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
 


### PR DESCRIPTION
DigitalOcean now blocks SMTP port 25 on new accounts (https://www.digitalocean.com/support/articles/smtp-block/) so it should not be recommended to new users.