### PR TITLE
Update avoid TLD list

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -158,7 +158,7 @@
 					<li title="will not support nameservers on a 4th level sub-domain">.cx</li>
 	    				<li title="requires own A record in DNS; each NS needs own PTR resource record">.is <a href="https://discourse.mailinabox.email/t/answered-no-you-cant-anyone-have-a-is-domain-working-with-miab-dns/1077"</a><i class="glyphicon glyphicon-comment" title="Link to discussion thread."></i></a> <a href="https://www.isnic.is/en/host/req"><i class="glyphicon glyphicon-globe" title="Link to registry requirements."></i></a></li>
 	    				<li title="requires two nameservers">.nl <a href="https://discourse.mailinabox.email/t/nameservers-setup-problems/572/3"</a><i class="glyphicon glyphicon-comment" title="Link to discussion thread."></i></a></li>
-					<li title="SpamAssassin suspicious nTLDs">.bid .buzz .click .date .faith .fit .fun .gdn .icu .life .online .ooo .pro .review .site .space .stream .top .work .world .xyz</li>
+					<li title="SpamAssassin suspicious nTLDs">.bid .buzz .click .cyou .date .faith .fit .fun .gdn .icu .life .online .ooo .pro .review .site .space .stream .top .trade .vip .work .world .xyz</li>
 
 		    			<div><i class="glyphicon glyphicon-comment"></i> indicates link to discussion. <i class="glyphicon glyphicon-globe" title="Link to registry requirements."></i> indicates link to TLD registry requirements.</li>
 	    			</ul>


### PR DESCRIPTION
Added additional domains labeled in spamassassin as `SUSP_URI_NTLD` [1].

[1] `/var/lib/spamassassin/3.004002/updates_spamassassin_org/72_active.cf`