### PR TITLE
Update documentation branch links to reflect branch rename

### DIFF
--- a/advanced-configuration.html
+++ b/advanced-configuration.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="guides.css" />
 </head>
 <body data-spy="scroll" data-target="#nav">
-	<a href="https://github.com/mail-in-a-box/mailinabox.email/blob/master/advanced-configuration.html" class="visible-md visible-lg"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+	<a href="https://github.com/mail-in-a-box/mailinabox.email/blob/main/advanced-configuration.html" class="visible-md visible-lg"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
 
 	<div id="back">
 		<div class="container">

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
 				<hr>
 				<p><a href="https://github.com/mail-in-a-box/mailinabox"><i class="icon-github"></i>github repository</a></p>
 				<p><a href="https://twitter.com/mailinabox"><i class="icon-twitter"></i>@Mailinabox</a></p>
-				<p><a href="https://github.com/mail-in-a-box/mailinabox/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a></p>
+				<p><a href="https://github.com/mail-in-a-box/mailinabox/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a></p>
 			</div>
 
 			<div class="col-sm-9 col-lg-8 col-sm-pull-3">
@@ -263,20 +263,20 @@
 
 					<p>The box also includes automatic DNS configuration when you let it become your nameserver so that it can set important DNS records for mail deliverability and security including <a href="https://en.wikipedia.org/wiki/Sender_Policy_Framework">SPF</a>, <a href="https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail">DKIM</a>, <a href="https://en.wikipedia.org/wiki/DMARC">DMARC</a>, and <a href="https://tools.ietf.org/html/rfc8461">MTA-STS</a>. When enabled, <a href="https://en.wikipedia.org/wiki/DNSSEC">DNSSEC</a> (with <a href="https://en.wikipedia.org/wiki/DNS-based_Authentication_of_Named_Entities">DANE TLSA</a>) provides a higher level of protection against active attacks with other mail servers also running DANE TLSA.</p>
 
-					<p>Mail-in-a-Box uses the latest security best practices, including using TLSv1.2, <a href="https://en.wikipedia.org/wiki/Opportunistic_encryption">opportunistic TLS</a> for outgoing mail, strong TLS ciphers, and <a href="https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security">HSTS</a> for the web services. TLS certificates are automatically provisioned from <a href="https://letsencrypt.org">Let&rsquo;s Encrypt</a>. (For more see our <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/security.md">security guide</a>.)</p>
+					<p>Mail-in-a-Box uses the latest security best practices, including using TLSv1.2, <a href="https://en.wikipedia.org/wiki/Opportunistic_encryption">opportunistic TLS</a> for outgoing mail, strong TLS ciphers, and <a href="https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security">HSTS</a> for the web services. TLS certificates are automatically provisioned from <a href="https://letsencrypt.org">Let&rsquo;s Encrypt</a>. (For more see our <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/security.md">security guide</a>.)</p>
 
 					<p>Your box can host mail for multiple users and multiple domain names. It also supports simple static website hosting (since the box is serving HTTP anyway), or you can host a website elsewhere (just add a custom DNS <code>A</code> record in you Mail-in-a-Box's control panel to point domains to another server).</p>
 
 					<p>Mail-in-a-Box includes a web-based control panel where you can add mail accounts, mail aliases, and custom DNS records and set up backups. The control panel displays comprehensive status checks for DNS records and system activity/monitoring. Control panel functionality can also be accessed over the RESTful HTTP API (<a href="api-docs.html">API documentation</a>).</p>
 
 					<p>Note that while we want everything to &ldquo;just work,&rdquo; we can&rsquo;t control the rest of the Internet. Other mail services might block or spam-filter email sent from your Mail-in-a-Box. This is a challenge faced by everyone who runs their own mail server, with or without Mail-in-a-Box. See our discussion forum for tips about that.</p>
-    			
+
     			<h2>How do I get it?</h2>
 
     				<p>The <a href="guide.html">setup guide</a> walks you through getting your own box set up. Users report it taking just a few hours to get to a fully operational system. And see the video above!</p>
 
 					<div class="alert alert-warning">
-						<strong>Legal note!</strong> Mail-in-a-Box is made available per the <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/LICENSE">CC0 public domain dedication</a>. By running Mail-in-a-Box, you will invoke scripts that use Let’s Encrypt to provision TLS certificates per the <a href="https://letsencrypt.org/repository/" target="_blank">Let’s Encrypt Subscriber Agreement(s) & Terms of Services</a>. Please be sure you accept the terms in both documents before beginning.
+						<strong>Legal note!</strong> Mail-in-a-Box is made available per the <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/LICENSE">CC0 public domain dedication</a>. By running Mail-in-a-Box, you will invoke scripts that use Let’s Encrypt to provision TLS certificates per the <a href="https://letsencrypt.org/repository/" target="_blank">Let’s Encrypt Subscriber Agreement(s) & Terms of Services</a>. Please be sure you accept the terms in both documents before beginning.
 					</div>
 
 	    			<p>If you are an expert and have a domain name and a <u>completely fresh</u> Ubuntu 18.04 machine running in the cloud, you basically just run on that machine:</p>
@@ -284,7 +284,7 @@
 	    			<div class="pre-wrap">
 						<pre>curl -s https://mailinabox.email/setup.sh | sudo bash</pre>
 					</div>
-					
+
 					<p>You will be asked to enter the email address you want and a few other configuration questions. Consult the <a href="guide.html">setup guide</a> for complete details. See the <a href="https://github.com/mail-in-a-box/mailinabox">README</a> on github for advanced instructions.</p>
 
 					<p>Please note that the goal of this project is to provide a simple, turn-key solution. There are basically no configuration options and you can&rsquo;t tweak the machine&rsquo;s configuration files after installation. If you are looking for something more advanced, try <a href="http://www.iredmail.org/">iRedMail</a> or <a href="https://github.com/tonioo/modoboa">Modoboa</a>.</p>
@@ -312,7 +312,7 @@
 
 				<h2>Development</h2>
 
-					<p>Mail-in-a-Box is based on Ubuntu 18.04 LTS 64-bit and uses very-well-documented shell scripts and a Python management daemon to configure the system. Take a look at the <a href="static/architecture.svg">system architecture diagram</a> and <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/security.md">security practices</a>.</p>
+					<p>Mail-in-a-Box is based on Ubuntu 18.04 LTS 64-bit and uses very-well-documented shell scripts and a Python management daemon to configure the system. Take a look at the <a href="static/architecture.svg">system architecture diagram</a> and <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/security.md">security practices</a>.</p>
 
 					<p>Development takes place on github at <a href="https://github.com/mail-in-a-box/mailinabox">https://github.com/mail-in-a-box/mailinabox</a>.</p>
 
@@ -321,11 +321,11 @@
 					<li>Make deploying a good mail server easy.</li>
 					<li>Promote <a href="http://redecentralize.org/">decentralization</a>, innovation, and privacy on the web.</li>
 					<li>Have automated, auditable, and <a href="https://sharknet.us/2014/02/01/automated-configuration-management-challenges-with-idempotency/">idempotent</a> system configuration.</li>
-					<li><strong>Not</strong> make a totally unhackable, NSA-proof server (but see our <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/security.md">security practices</a>).</li>
+					<li><strong>Not</strong> make a totally unhackable, NSA-proof server (but see our <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/security.md">security practices</a>).</li>
 					<li><strong>Not</strong> make something customizable by power users.</li>
 					</ul>
 
-					<p>Additionally, this project has a <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a>, which supersedes the goals above. Please review it when joining our community.</p>
+					<p>Additionally, this project has a <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>, which supersedes the goals above. Please review it when joining our community.</p>
 
 					<p>Mail-in-a-Box is dedicated to the public domain using <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>.</p>
 

--- a/maintenance.html
+++ b/maintenance.html
@@ -26,7 +26,7 @@
     </style>
 </head>
 <body data-spy="scroll" data-target="#nav">
-	<a href="https://github.com/mail-in-a-box/mailinabox.email/blob/master/maintenance.html" class="visible-md visible-lg"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+	<a href="https://github.com/mail-in-a-box/mailinabox.email/blob/main/maintenance.html" class="visible-md visible-lg"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
 
 	<div id="back">
 		<div class="container">
@@ -111,14 +111,14 @@
 
 					<p>You should move to the latest Mail-in-a-Box release as releases are posted, especially if an update addresses any security issues, although you do not necessarily need to do so. We will post release announcements to our twitter account <a href="https://twitter.com/mailinabox">@mailinabox</a>, the <a href="https://discourse.mailinabox.email/c/announcements">announcements section of the discussion forum</a>, and our Slack chat (see the homepage).</p>
 
-					<p>Check the <a href="https://github.com/mail-in-a-box/mailinabox/blob/master/CHANGELOG.md">release notes</a> prior to updating to see what&rsquo;s been changed in the latest version.</p>
+					<p>Check the <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/CHANGELOG.md">release notes</a> prior to updating to see what&rsquo;s been changed in the latest version.</p>
 
 					<div class="alert alert-warning" role="alert">
 	    				<p>If you are upgrading from Mail-in-a-Box version v0.30 or earlier on <strong>Ubuntu 14.04</strong> to version 0.40 or later on <strong>Ubuntu 18.04</strong>:</p>
 	    				<p>1. Follow the instructions in this section to upgrade your existing Mail-in-a-Box to v0.30, the last version supporting Ubuntu 14.04. (<a href="https://discourse.mailinabox.email/t/mail-in-a-box-version-v0-40-and-moving-to-ubuntu-18-04/4289">As noted in the forum</a>, upgrading the Nextcloud components can be challenging now due to package deprecation.)</p>
 	    				<p>2. After your existing box is up to date with v0.30, then proceed to the section below <strong>Moving to a New Box</strong> to migrate your system to a new machine running Ubuntu 18.04 and version 0.40 of Mail-in-a-Box.</p>
 	    			</div>
-	    				
+
 					<p>To upgrade Mail-in-a-Box to the latest release, first close any web browser pages related to your instance of Mail-in-a-Box, then log into your machine using <code>SSH</code> in exactly the same manner as when you were setting up the box (see the setup guide section called <a href="guide.html#setup">Setting Up The Box</a> for a reminder of what that looked like).</p>
 
 					<p>Then, once logged in, run:</p>


### PR DESCRIPTION
Just changed `master` to `main` in the URLs