### PR TITLE
Update link to Dovecot Sieve documentation

### DIFF
--- a/advanced-configuration.html
+++ b/advanced-configuration.html
@@ -114,7 +114,7 @@ fileinto :create "backup-mailbox";
 </code></pre></p>
 				  <p>Note that Mail-in-a-Box contains a sieve script to filter Spam which cannot be altered. When the header contains X-Spam-Status with value Yes, the email is filed into the Spam mailbox.</p>
 
-				  <p>For information on what is possible with Dovecot Pigeonhole Sieve, as well as examples, see <a href="https://wiki2.dovecot.org/Pigeonhole/Sieve">https://wiki2.dovecot.org/Pigeonhole/Sieve</a></p>
+				  <p>For information on what is possible with Dovecot Pigeonhole Sieve, as well as examples, see <a href="https://doc.dovecot.org/configuration_manual/sieve/pigeonhole_sieve_interpreter/">https://doc.dovecot.org/configuration_manual/sieve/pigeonhole_sieve_interpreter/</a></p>
 
 					<div class="hidden-xs" style="height: 200px"> </div>
 


### PR DESCRIPTION
The current documentation links to https://wiki2.dovecot.org/Pigeonhole/Sieve which currently shows a redirect to a new location:

![image](https://user-images.githubusercontent.com/261361/138701094-81636439-5367-43c6-9247-f69111476df1.png)
