### PR TITLE
Add note about SPF record when relaying emails

### DIFF
--- a/advanced-configuration.html
+++ b/advanced-configuration.html
@@ -94,6 +94,8 @@ smtp_sasl_tls_security_options = </code></pre>
 
 					<p>And that's it. Mail created and dispatched on the remote machine will now be routed via your Mail-in-a-Box.</p>
 
+				        <p>To avoid issues with spam filters, it is recommended to add all remote machines sending email via the relay to your SPF record. For example: <code>v=spf1 mx ip4:1.2.3.4 -all</code></p>
+
 					<p>You can send a test email on the remote machine by running:</p>
 
 					<pre>echo "relay test" | mail -s "relay test" destinationuser@destinationdomain</pre>


### PR DESCRIPTION
I have a couple of servers which are configured to relay email via my mailinabox. The `TO:` address of those emails is an email managed by the mailinabox.

I still get SPF and DMARC fails on those emails.

The spam classification in the emails:

```
X-Spam-Report: 
	*  5.0 SPF_FAIL SPF check failed
	*  5.0 DMARC_FAIL_QUARANTINE DMARC check failed (p=quarantine)
	*  0.0 HTML_MESSAGE BODY: HTML included in message
	* -0.0 T_SCC_BODY_TEXT_LINE No description available.
X-Spam-Score: 10.0
```

Adding my relay servers to my SPF record seemed to have solved the issue.

I would suggest adding that information to the documentation.