### PR TITLE
Update documentation about relay setup

### DIFF
--- a/advanced-configuration.html
+++ b/advanced-configuration.html
@@ -56,23 +56,26 @@
 
 					<p>If you have other machines sending mail using a domain name hosted on your Mail-in-a-Box (e.g. a webserver, or any machine that has cron jobs you want to see the output of) we recommend that you configure those machines to relay their outbound mail via the Mail-in-a-Box. Otherwise those emails may be marked as spam by recipients.</p>
 
-					<p>If the sending machine is running Ubuntu 14.04 this can be done as follows. No changes are required on the Mail-in-a-Box itself (other than the creation of a mail account for the remote machine to authenticate with, and optionally the creation of aliases to authorize the remote machine to send from multiple addresses); <em>all commands that follow are to be run on the remote machine</em>.</p>
+					<p>If the sending machine is running Ubuntu 18.04 this can be done as follows. No changes are required on the Mail-in-a-Box itself (other than the creation of a mail account for the remote machine to authenticate with, and optionally the creation of aliases to authorize the remote machine to send from multiple addresses); <em>all commands that follow are to be run on the remote machine</em>.</p>
 
 					<ol>
 						<li>Run <code>sudo apt-get install postfix</code> and choose &ldquo;Satellite system&rdquo; when prompted.
 							<ul>
-								<li>It's important to include the SMTP port for the relay host, for example: <code>box.example.com:587</code></li>
+								<li>It's important to include the SMTP port for the relay host, for example: <code>box.example.com:465</code></li>
 							</ul>
 						</li>
 						<li>
-							<p>Append the following seven lines to <code>/etc/postfix/main.cf</code>:</p>
+							<p>Append the following lines to <code>/etc/postfix/main.cf</code>:</p>
 							<pre><code>mydestination =
+smtp_tls_wrappermode = yes
 smtp_tls_security_level = verify
 smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = hash:/etc/postfix/relay_password
 smtp_sasl_tls_security_options = </code></pre>
 						</li>
+            <li>Ensure the relay host is correctly set in <code>/etc/postfix/main.cf</code>: <code>relayhost = [box.example.com]:465</code>
+            </li>
 						<li>
 							<p>Write credentials in the following form to <code>/etc/postfix/relay_password</code> (substitute the second and third values with credentials for a freshly created account on the Mail-in-a-Box, and the first with the hostname of your Mail-in-a-Box):</p>
 							<pre><code>yourmailinabox.yourdomain relayusername:relaypassword</code></pre>


### PR DESCRIPTION
This is a followup of #90, which is obsolete as SPF changes are not required for relaying.

## Changes

* Updated port as mailinabox seems to be using `465` nowadays instead of `587`.
* Add `smtp_tls_wrappermode = yes` to the postfix configuration. I otherwise get: `postfix/smtp[109]: SMTPS wrappermode (TCP port 465) requires setting "smtp_tls_wrappermode = yes", and "smtp_tls_security_level = encrypt" (or stronger)`
* Add note to set `relayhost` in the postfix configuration, if not done otherwise.

I tested the setup within a Debian docker container. I assume that it also works for Ubuntu 18.04.