### PR TITLE
rename ubuntu 18.04 -> 22.04

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -192,7 +192,7 @@
 
 	    			<p>Now you will rent a machine, or a virtual part of a machine, somewhere in &ldquo;the cloud.&rdquo; We&rsquo;ll call this machine your box. We recommend going over to <a href="https://www.linode.com/">Linode</a>, <a href="https://www.1and1.com/">1&amp;1</a>, or <a href="https://rimuhosting.com/order/v2orderstart.jsp">Rimuhosting.com</a>. (Most cloud providers will do, but not Amazon Web Services because its network is often blocked to prevent users from sending spam.)</p>
 
-					<p><strong>You must choose the <code>Ubuntu 18.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
+					<p><strong>You must choose the <code>Ubuntu 22.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
 
 				<p>If you choose Digital Ocean, your machine is called a &ldquo;droplet&rdquo; and you <strong>must</strong> name your droplet the same as its hostname.</p>
 

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
 						<strong>Legal note!</strong> Mail-in-a-Box is made available per the <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/LICENSE">CC0 public domain dedication</a>. By running Mail-in-a-Box, you will invoke scripts that use Let’s Encrypt to provision TLS certificates per the <a href="https://letsencrypt.org/repository/" target="_blank">Let’s Encrypt Subscriber Agreement(s) & Terms of Services</a>. Please be sure you accept the terms in both documents before beginning.
 					</div>
 
-	    			<p>If you are an expert and have a domain name and a <u>completely fresh</u> Ubuntu 18.04 machine (note that containers and modified images are not supported) running in the cloud, you basically just run on that machine:</p>
+	    			<p>If you are an expert and have a domain name and a <u>completely fresh</u> Ubuntu 22.04 machine (note that containers and modified images are not supported) running in the cloud, you basically just run on that machine:</p>
 
 	    			<div class="pre-wrap">
 						<pre>curl -s https://mailinabox.email/setup.sh | sudo bash</pre>
@@ -317,7 +317,7 @@
 
 				<h2>Development</h2>
 
-					<p>Mail-in-a-Box is based on Ubuntu 18.04 LTS 64-bit and uses very-well-documented shell scripts and a Python management daemon to configure the system. Take a look at the <a href="static/architecture.svg">system architecture diagram</a> and <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/security.md">security practices</a>.</p>
+					<p>Mail-in-a-Box is based on Ubuntu 22.04 LTS 64-bit and uses very-well-documented shell scripts and a Python management daemon to configure the system. Take a look at the <a href="static/architecture.svg">system architecture diagram</a> and <a href="https://github.com/mail-in-a-box/mailinabox/blob/main/security.md">security practices</a>.</p>
 
 					<p>Development takes place on github at <a href="https://github.com/mail-in-a-box/mailinabox">https://github.com/mail-in-a-box/mailinabox</a>.</p>
 

--- a/maintenance.html
+++ b/maintenance.html
@@ -115,8 +115,8 @@
 
 					<div class="alert alert-warning" role="alert">
 	    				<p>If you are upgrading from Mail-in-a-Box version 5x or earlier on <strong>Ubuntu 18.04</strong> to version 60 or later on <strong>Ubuntu 22.04</strong>:</p>
-	    				<p>1. Follow the instructions in this section to upgrade your existing Mail-in-a-Box to the latest version supporting Ubuntu 22.04.</p>
-	    				<p>2. After your existing box is up to date with version 5x, then proceed to the section below <strong>Moving to a New Box</strong> to migrate your system to a new machine running Ubuntu 22.04 and version 60 (or later) of Mail-in-a-Box.</p>
+	    				<p>1. Follow the instructions in this section to upgrade your <em>existing</em> Mail-in-a-Box box (running Ubuntu 18.04) to the latest version of Mail-in-a-Box supporting that version of Ubuntu.</p>
+	    				<p>2. After your existing box is up to date with the latest version of Mail-in-a-Box supporting Ubuntu 18.04, then proceed to the section below <strong>Moving to a New Box</strong> to migrate your system to a new machine running Ubuntu 22.04 and version 60 (or later) of Mail-in-a-Box.</p>
 	    			</div>
 
 					<p>To upgrade Mail-in-a-Box to the latest release, first close any web browser pages related to your instance of Mail-in-a-Box, then log into your machine using <code>SSH</code> in exactly the same manner as when you were setting up the box (see the setup guide section called <a href="guide.html#setup">Setting Up The Box</a> for a reminder of what that looked like).</p>

--- a/maintenance.html
+++ b/maintenance.html
@@ -115,8 +115,8 @@
 
 					<div class="alert alert-warning" role="alert">
 	    				<p>If you are upgrading from Mail-in-a-Box version 5x or earlier on <strong>Ubuntu 18.04</strong> to version 60 or later on <strong>Ubuntu 22.04</strong>:</p>
-	    				<p>1. Follow the instructions in this section to upgrade your existing Mail-in-a-Box to the latest version supporting Ubuntu 18.04.</p>
-	    				<p>2. After your existing box is up to date with version 5x, then proceed to the section below <strong>Moving to a New Box</strong> to migrate your system to a new machine running Ubuntu 12.04 and version 60 (or later) of Mail-in-a-Box.</p>
+	    				<p>1. Follow the instructions in this section to upgrade your existing Mail-in-a-Box to the latest version supporting Ubuntu 22.04.</p>
+	    				<p>2. After your existing box is up to date with version 5x, then proceed to the section below <strong>Moving to a New Box</strong> to migrate your system to a new machine running Ubuntu 22.04 and version 60 (or later) of Mail-in-a-Box.</p>
 	    			</div>
 
 					<p>To upgrade Mail-in-a-Box to the latest release, first close any web browser pages related to your instance of Mail-in-a-Box, then log into your machine using <code>SSH</code> in exactly the same manner as when you were setting up the box (see the setup guide section called <a href="guide.html#setup">Setting Up The Box</a> for a reminder of what that looked like).</p>
@@ -147,7 +147,7 @@
 					<p>Moving your data to a new box is only supported if your existing Mail-in-a-Box box is up to date with the latest version of Mail-in-a-Box. So follow the steps in <i>Upgrading Mail-in-a-Box</i> above to upgrade to the latest version of Mail-in-a-Box before proceeding.</p>
 
 					<div class="alert alert-warning" role="alert">
-	    				If you are upgrading from Mail-in-a-Box version v0.50 or earlier on <strong>Ubuntu 18.04</strong> to version 60 or later on <strong>Ubuntu 22.04</strong>, you must follow the instructions in the previous section to uprade your existing Mail-in-a-Box to v0.51 or a later "5x" version first.
+	    				If you are upgrading from Mail-in-a-Box version v0.50 or earlier on <strong>Ubuntu 18.04</strong> to version 60 or later on <strong>Ubuntu 22.04</strong>, you must follow the instructions in the previous section to upgrade your existing Mail-in-a-Box to v0.51 or a later "5x" version first.
 	    			</div>
 
 	    			<h3>Perform one last backup on the old machine</h3>


### PR DESCRIPTION
When migrating to v60 running on ubuntu 22.04, I noticed that a lot of the docs still referred to MIAB as running on 18.04. I thought I'd change the docs to reflect the changes. 
