### PR TITLE
Deleting the contents of the /home/user-data/ssl

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -192,7 +192,7 @@
 
 	    			<p>Now you will rent a machine, or a virtual part of a machine, somewhere in &ldquo;the cloud.&rdquo; We&rsquo;ll call this machine your box. We recommend going over to <a href="https://www.linode.com/">Linode</a>, <a href="https://www.1and1.com/">1&amp;1</a>, or <a href="https://rimuhosting.com/order/v2orderstart.jsp">Rimuhosting.com</a>. (Most cloud providers will do, but not Amazon Web Services because its network is often blocked to prevent users from sending spam.)</p>
 
-					<p><strong>You must choose the <code>Ubuntu 18.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
+					<p><strong>You must choose the <code>Ubuntu 22.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
 
 				<p>If you choose Digital Ocean, your machine is called a &ldquo;droplet&rdquo; and you <strong>must</strong> name your droplet the same as its hostname.</p>
 

--- a/maintenance.html
+++ b/maintenance.html
@@ -169,7 +169,14 @@ sudo management/backup.py</pre>
 
 	    			<p>Then follow the steps in the setup guide&rsquo;s section <a href="guide.html#setup">Setting Up The Box</a>. When you are prompted for the box&rsquo;s hostname, you will need to use the hostname that you are currently using.</p>
 
-	    			<h3>Restore your mail data (and other files)</h3>
+				<h3>Clean up SSL files</h3>
+				
+					<p>When you set up a new machine, a self-signed SSL certificate will be generated.  The presence of this data will cause nginx to not restart properly, so let's delete this data.  Run:</p>
+
+					<pre> sudo rm -rf /home/user-data/ssl/* </pre>
+
+				
+				<h3>Restore your mail data (and other files)</h3>
 
 	    			<p>Next you&rsquo;ll restore your mail data and other files to the new machine.</p>
 


### PR DESCRIPTION

When a new box is created the ssl data directory contains a self-signed certificate.  When the backup is restored, this data then conflicts with the backed up data causing nginx to not restart.  Deleting the contents of the /home/user-data/ssl directory will solve this issue.
