### PR TITLE
Proposal: remove 404 badge.svg ?

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,6 @@
 				<p><a href="guide.html"><i class="icon-th-list"></i>setup guide</a></p>
 				<p><a href="https://discourse.mailinabox.email/"><i class="icon-chat"></i>discussion forum</a></p>
 				<p style="margin-bottom: 2px"><a href="/slack"><i class="icon-slack"></i> chat room</a></p>
-				<p style="margin-left: 2em"><img src="https://mailinabox.email/slack/badge.svg"></p>
 				<hr>
 				<p><a href="maintenance.html"><i class="icon-back-in-time"></i>maintenance guide</a></p>
 				<p><a href="advanced-configuration.html"><i class="icon-th-list"></i>advanced tips</a></p>


### PR DESCRIPTION
Hi there! 

On the MIAB web page there's a 404 for the slack badge at /slack/badge.svg. 

I don't know if you're currently working to replace the badge, but in the meantime maybe it could be removed?

Currently:
![image](https://github.com/mail-in-a-box/mailinabox.email/assets/282865/7e5b7f99-a75f-4c8e-b0bd-f8e0ffbfb32a)

With this change:
![image](https://github.com/mail-in-a-box/mailinabox.email/assets/282865/15a5d0dc-1c78-4988-82b8-dce4d7f9c8fc)
